### PR TITLE
Update 0221-multiple-modules.md

### DIFF
--- a/proposals/0221-multiple-modules.md
+++ b/proposals/0221-multiple-modules.md
@@ -78,7 +78,10 @@ The `moduleId` is defined as optional in order to keep backward compatibility. I
 
 In addition, this proposal deprecates the `SupportedSeat` Enumeration and parameter `id` in `SeatControlData` in order to get a uniformed solution.
 
-If a mobile app uses the `SupportedSeat` `id` and no `moduleId` in a RPC request, SDL shall forward the request as is to HMI, HMI shall automatically convert seat `id=DRIVER` to the `moduleId` that corresponds to the driver’s seat module, and seat `id=FRONT_PASSENGER` to the `moduleId` that corresponds to the front passenger's seat. If a mobile app includes both `SupportedSeat` `id` and `moduleId` in a RPC request, `id` shall be ignored since `moduleId` has a higher priority.
+If a mobile app uses the `SupportedSeat` `id` and omits `moduleId` in a RPC request, SDL shall add the `moduleId` parameter to HMI request according to the following rules:
+ - if `id = DRIVER`  then `moduleId = <moduleId of first published module in seatControlCapabilities>`
+ - if `id = FRONT_PASSENGER` then `moduleId = <moduleId of second published module in seatControlCapabilities>`
+If a mobile app includes both `SupportedSeat` `id` and `moduleId` in a RPC request, SDL shall forward the request as is to HMI.
 
 ### Define the Grid
 
@@ -425,6 +428,13 @@ The following HMI API needs an update and needs to be added to mobile API.
 +       <description>See SeatLocationCapability, all available seat locations shall be returned.</description>
 +   </param>
 </function>
+
+<struct name="SeatControlData">
+    <description>Seat control data corresponds to "SEAT" ModuleType. </description>
+-   <param name="id" type="SupportedSeat" mandatory="true"></param>
++   <param name="id" type="SupportedSeat" mandatory="false"></param>
+    ...
+</struct>
 
 </interface>
 ```


### PR DESCRIPTION
## Introduction

Update [SDL-0221 Remote Control - Allow Multiple Modules per Module Type](https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0221-multiple-modules.md) with changes :

1. Make `SeatControlData::id` parameter not mandatory for compatibility with the MOBILE_API. The RPC Spec has deprecated the `SeatControlData::id` parameter.

2. Change rules for processing `ModuleType::SEAT` when the `SeatControlData::id` parameter is missing from the mobile request. This change is for backward compatibility with older apps

## Motivation

The accepted proposal does not provide backwards compatibility for older SDL apps that do not use the Seat module parameter `moduleId`

## Proposed solution

### Old :

If a mobile app uses the `SupportedSeat` `id` and no `moduleId` in a RPC request, SDL shall forward the request as is to the HMI. The HMI shall automatically convert seat `id=DRIVER` to the `moduleId` that corresponds to the driver’s seat module, and seat `id=FRONT_PASSENGER` to the `moduleId` that corresponds to the front passenger's seat. If a mobile app includes both `id` and `moduleId` in a RPC request, `id` shall be ignored since `moduleId` has a higher priority.

### New :

If a mobile app uses the `SupportedSeat` `id` and omits `moduleId` in a RPC request, SDL shall add the `moduleId` parameter to HMI request according to the following rules:

- if `id = DRIVER` then `moduleId` =  `moduleId of first published module in seatControlCapabilities`

- if `id = FRONT_PASSENGER` then `moduleId` =  `moduleId of second published module in seatControlCapabilities`


If a mobile app includes both `SupportedSeat` `id` and `moduleId` in a RPC request, SDL shall forward the request as is to HMI.

### New :

Add to HMI_API

```
<struct name="SeatControlData">
    <description>Seat control data corresponds to "SEAT" ModuleType. </description>
-   <param name="id" type="SupportedSeat" mandatory="true"></param>
+   <param name="id" type="SupportedSeat" mandatory="false"></param>
    ...
</struct>
```
